### PR TITLE
units: support extra data

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -120,7 +120,6 @@ CGO_ENABLED=0 go build
             {
                 "ipaddress": "172.23.21.3",
                 "id": "<unit_id>",
-                "name": "fw.nethsecurity.local",
                 "netmask": "255.255.255.0",
                 "registered": true,
                 "vpn": {
@@ -129,8 +128,15 @@ CGO_ENABLED=0 go build
                     "connected_since": "1686312722",
                     "real_address": "192.168.122.220:41445",
                     "virtual_address": "172.23.21.3"
+                },
+                "info": {
+                    "unit_id": "fba703c1-6c2d-4d3d-9dab-5998c7b66700",
+                    "unit_name": "fw.local",
+                    "version": "8-23.05.2-ns.0.0.2-beta2-37-g6e74afc",
+                    "subscription_type": "enterprise",
+                    "system_id": "XXXXXXXX-XXXX",
+                    "created": "2024-03-14T15:18:08Z"
                 }
-
             },
             ...
             {
@@ -138,7 +144,15 @@ CGO_ENABLED=0 go build
                 "id": "<unit_id>",
                 "netmask": "",
                 "registered": false,
-                "vpn": {}
+                "vpn": {},
+                "info": {
+                    "unit_id": "zzzzzzzz-d9f3-44b7-b277-36d65cf139e6",
+                    "unit_name": "fw.nethsecurity.local",
+                    "version": "8-23.05.2-ns.0.0.2-beta2-37-g6e74afc",
+                    "subscription_type": "",
+                    "system_id": "",
+                    "created": "2024-03-14T15:16:02Z"
+                }
             }
         ],
         "message": "units listed successfully"
@@ -162,15 +176,22 @@ CGO_ENABLED=0 go build
         "data": {
             "ipaddress": "172.23.21.3",
             "id": "<unit_id>",
-            "name": "fw.nethsecurity.local",
             "netmask": "255.255.255.0",
             "registered": true,
             "vpn": {
-            "bytes_rcvd": "22030",
-            "bytes_sent": "5841",
-            "connected_since": "1686312722",
-            "real_address": "192.168.122.220:41445",
-            "virtual_address": "172.23.21.3"
+                "bytes_rcvd": "22030",
+                "bytes_sent": "5841",
+                "connected_since": "1686312722",
+                "real_address": "192.168.122.220:41445",
+                "virtual_address": "172.23.21.3"
+            },
+            "info": {
+                "unit_id": "fba703c1-6c2d-4d3d-9dab-5998c7b66700",
+                "unit_name": "fw.local",
+                "version": "8-23.05.2-ns.0.0.2-beta2-37-g6e74afc",
+                "subscription_type": "enterprise",
+                "system_id": "XXXXXXXX-XXXX",
+                "created": "2024-03-14T15:18:08Z"
             }
         },
         "message": "unit listed successfully"
@@ -234,7 +255,10 @@ CGO_ENABLED=0 go build
         "unit_name": "fw.nethsecurity.local",
         "unit_id": "d330b2db-cdfe-4c56-b9b6-f97e5b838748",
         "username": "test",
-        "password": "Nethesis,1234"
+        "password": "Nethesis,1234",
+        "version": "8-23.05.2-ns.0.0.2-beta2-37-g6e74afc",
+        "subscription_type": "enterprise",
+        "system_id": "XXXXXXXX-XXXX",
      }
     ```
 

--- a/api/methods/unit.go
+++ b/api/methods/unit.go
@@ -73,6 +73,9 @@ func GetUnits(c *gin.Context) {
 		return
 	}
 
+	// get unit data from database
+	db_info, _ := storage.GetUnits()
+
 	// loop through units
 	var results []gin.H
 	for _, e := range units {
@@ -123,6 +126,14 @@ func GetUnits(c *gin.Context) {
 			result["vpn"] = vpns[id]
 		} else {
 			result["vpn"] = gin.H{}
+		}
+
+		// add db info
+		info, ok := db_info[id]
+		if ok {
+			result["info"] = info
+		} else {
+			result["info"] = gin.H{}
 		}
 
 		// append to array
@@ -200,6 +211,14 @@ func GetUnit(c *gin.Context) {
 		result["vpn"] = vpn
 	} else {
 		result["vpn"] = gin.H{}
+	}
+
+	// retrieve unit info from database
+	info, err := storage.GetUnit(unitId)
+	if err == nil {
+		result["info"] = info
+	} else {
+		result["info"] = gin.H{}
 	}
 
 	// return 200 OK with data

--- a/api/methods/unit.go
+++ b/api/methods/unit.go
@@ -74,7 +74,11 @@ func GetUnits(c *gin.Context) {
 	}
 
 	// get unit data from database
-	db_info, _ := storage.GetUnits()
+	unitRows, _ := storage.GetUnits()
+	dbInfo := make(map[string]models.Unit)
+	for _, unitRow := range unitRows {
+		dbInfo[unitRow.ID] = unitRow
+	}
 
 	// loop through units
 	var results []gin.H
@@ -108,6 +112,14 @@ func GetUnits(c *gin.Context) {
 			result["vpn"] = gin.H{}
 		}
 
+		// add db info
+		info, ok := dbInfo[e.Name()]
+		if ok {
+			result["info"] = info
+		} else {
+			result["info"] = gin.H{}
+		}
+
 		// append to array
 		results = append(results, result)
 	}
@@ -129,7 +141,7 @@ func GetUnits(c *gin.Context) {
 		}
 
 		// add db info
-		info, ok := db_info[id]
+		info, ok := dbInfo[id]
 		if ok {
 			result["info"] = info
 		} else {
@@ -557,7 +569,7 @@ func RegisterUnit(c *gin.Context) {
 			return
 		}
 
-		errAdd := storage.UpdateUnit(jsonRequest.UnitId, jsonRequest.UnitName, jsonRequest.Version, jsonRequest.SubscriptionType, jsonRequest.SystemId)
+		errAdd := storage.AddOrUpdateUnit(jsonRequest.UnitId, jsonRequest.UnitName, jsonRequest.Version, jsonRequest.SubscriptionType, jsonRequest.SystemId)
 		if errAdd != nil {
 			c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
 				Code:    400,
@@ -580,7 +592,7 @@ func RegisterUnit(c *gin.Context) {
 			"password": jsonRequest.Password,
 		}
 
-		errAdd := storage.AddUnit(jsonRequest.UnitId, jsonRequest.UnitName, jsonRequest.Version, jsonRequest.SubscriptionType, jsonRequest.SystemId)
+		errAdd := storage.AddOrUpdateUnit(jsonRequest.UnitId, jsonRequest.UnitName, jsonRequest.Version, jsonRequest.SubscriptionType, jsonRequest.SystemId)
 		if errAdd != nil {
 			c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
 				Code:    400,

--- a/api/methods/unit.go
+++ b/api/methods/unit.go
@@ -23,6 +23,7 @@ import (
 	"github.com/NethServer/nethsecurity-controller/api/global"
 	"github.com/NethServer/nethsecurity-controller/api/models"
 	"github.com/NethServer/nethsecurity-controller/api/socket"
+	"github.com/NethServer/nethsecurity-controller/api/storage"
 	"github.com/NethServer/nethsecurity-controller/api/utils"
 
 	"github.com/fatih/structs"
@@ -537,6 +538,16 @@ func RegisterUnit(c *gin.Context) {
 			return
 		}
 
+		errAdd := storage.UpdateUnit(jsonRequest.UnitId, jsonRequest.UnitName, jsonRequest.Version, jsonRequest.SubscriptionType, jsonRequest.SystemId)
+		if errAdd != nil {
+			c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
+				Code:    400,
+				Message: "cannot add update to database for: " + jsonRequest.UnitId,
+				Data:    errAdd.Error(),
+			}))
+			return
+		}
+
 		// return 200 OK with data
 		c.JSON(http.StatusOK, structs.Map(response.StatusOK{
 			Code:    200,
@@ -548,6 +559,16 @@ func RegisterUnit(c *gin.Context) {
 		global.WaitingList[jsonRequest.UnitId] = gin.H{
 			"username": jsonRequest.Username,
 			"password": jsonRequest.Password,
+		}
+
+		errAdd := storage.AddUnit(jsonRequest.UnitId, jsonRequest.UnitName, jsonRequest.Version, jsonRequest.SubscriptionType, jsonRequest.SystemId)
+		if errAdd != nil {
+			c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
+				Code:    400,
+				Message: "cannot add unit to database for: " + jsonRequest.UnitId,
+				Data:    errAdd.Error(),
+			}))
+			return
 		}
 
 		// return forbidden state

--- a/api/models/unit.go
+++ b/api/models/unit.go
@@ -14,7 +14,11 @@ type AddRequest struct {
 }
 
 type RegisterRequest struct {
-	UnitId   string `json:"unit_id" binding:"required"`
-	Username string `json:"username" binding:"required"`
-	Password string `json:"password" binding:"required"`
+	UnitId           string `json:"unit_id" binding:"required"`
+	Username         string `json:"username" binding:"required"`
+	Password         string `json:"password" binding:"required"`
+	UnitName         string `json:"unit_name" binding:"required"`
+	Version          string `json:"version"`
+	SubscriptionType string `json:"subscription_type"`
+	SystemId         string `json:"system_id"`
 }

--- a/api/models/unit.go
+++ b/api/models/unit.go
@@ -9,6 +9,8 @@
 
 package models
 
+import "time"
+
 type AddRequest struct {
 	UnitId string `json:"unit_id" binding:"required"`
 }
@@ -21,4 +23,13 @@ type RegisterRequest struct {
 	Version          string `json:"version"`
 	SubscriptionType string `json:"subscription_type"`
 	SystemId         string `json:"system_id"`
+}
+
+type Unit struct {
+	ID               string    `json:"unit_id" structs:"id"`
+	Name             string    `json:"unit_name" structs:"name"`
+	Version          string    `json:"version" structs:"version"`
+	SubscriptionType string    `json:"subscription_type" structs:"subscription_type"`
+	SystemID         string    `json:"system_id" structs:"system_id"`
+	Created          time.Time `json:"created" structs:"created"`
 }

--- a/api/storage/schema.sql
+++ b/api/storage/schema.sql
@@ -14,3 +14,12 @@ CREATE TABLE accounts (
     `display_name` TEXT,
     `created` TIMESTAMP NOT NULL
 );
+
+CREATE TABLE units (
+    `id` TEXT NOT NULL PRIMARY KEY,
+    `name` TEXT NOT NULL UNIQUE,
+    `version` TEXT NOT NULL,
+    `system_id` TEXT,
+    `subscription_type` TEXT,
+    `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/api/storage/storage.go
+++ b/api/storage/storage.go
@@ -249,13 +249,13 @@ func UpdatePassword(accountUsername string, newPassword string) error {
 	return err
 }
 
-func AddUnit(unitID string, unitName string, version string, subscriptionType string, systemID string) error {
+func AddOrUpdateUnit(unitID string, unitName string, version string, subscriptionType string, systemID string) error {
 	// get db
 	db := Instance()
 
 	// define query
 	_, err := db.Exec(
-		"INSERT INTO units (id, name, version, subscription_type, system_id) VALUES (?, ?, ?, ?, ?)",
+		"REPLACE INTO units (id, name, version, subscription_type, system_id) VALUES (?, ?, ?, ?, ?)",
 		unitID,
 		unitName,
 		version,
@@ -265,29 +265,7 @@ func AddUnit(unitID string, unitName string, version string, subscriptionType st
 
 	// check error
 	if err != nil {
-		logs.Logs.Println("[ERR][STORAGE][ADD_UNIT] error in insert units query: " + err.Error())
-	}
-
-	return err
-}
-
-func UpdateUnit(unitID string, unitName string, version string, subscriptionType string, systemID string) error {
-	// get db
-	db := Instance()
-
-	// define query
-	_, err := db.Exec(
-		"UPDATE units set name = ?, version = ?, subscription_type = ?, system_id = ? WHERE id = ?",
-		unitName,
-		version,
-		subscriptionType,
-		systemID,
-		unitID,
-	)
-
-	// check error
-	if err != nil {
-		logs.Logs.Println("[ERR][STORAGE][UPDATE_UNIT] error in update units query: " + err.Error())
+		logs.Logs.Println("[ERR][STORAGE][ADD_OR_UPDATE_UNIT] error in insert units query: " + err.Error())
 	}
 
 	return err
@@ -317,7 +295,7 @@ func GetUnit(unitId string) (models.Unit, error) {
 	return result, err
 }
 
-func GetUnits() (map[string]models.Unit, error) {
+func GetUnits() ([]models.Unit, error) {
 	// get db
 	db := Instance()
 
@@ -341,11 +319,6 @@ func GetUnits() (map[string]models.Unit, error) {
 		results = append(results, unitRow)
 	}
 
-	unitMap := make(map[string]models.Unit)
-	for _, unitRow := range results {
-		unitMap[unitRow.ID] = unitRow
-	}
-
 	// return results
-	return unitMap, err
+	return results, err
 }

--- a/api/storage/storage.go
+++ b/api/storage/storage.go
@@ -292,3 +292,60 @@ func UpdateUnit(unitID string, unitName string, version string, subscriptionType
 
 	return err
 }
+
+func GetUnit(unitId string) (models.Unit, error) {
+	// get db
+	db := Instance()
+
+	// define query
+	query := "SELECT id, name, version, subscription_type, system_id, created FROM units where id = ?"
+	rows, err := db.Query(query, unitId)
+	if err != nil {
+		logs.Logs.Println("[ERR][STORAGE][GET_UNIT] error in query execution:" + err.Error())
+	}
+	defer rows.Close()
+
+	// loop rows
+	var result models.Unit
+	for rows.Next() {
+		if err := rows.Scan(&result.ID, &result.Name, &result.Version, &result.SubscriptionType, &result.SystemID); err != nil {
+			logs.Logs.Println("[ERR][STORAGE][GET_UNIT] error in query row extraction" + err.Error())
+		}
+	}
+
+	// return results
+	return result, err
+}
+
+func GetUnits() (map[string]models.Unit, error) {
+	// get db
+	db := Instance()
+
+	// define query
+	query := "SELECT id, name, version, subscription_type, system_id, created FROM units"
+	rows, err := db.Query(query)
+	if err != nil {
+		logs.Logs.Println("[ERR][STORAGE][GET_UNITS] error in query execution:" + err.Error())
+	}
+	defer rows.Close()
+
+	// loop rows
+	var results []models.Unit
+	for rows.Next() {
+		var unitRow models.Unit
+		if err := rows.Scan(&unitRow.ID, &unitRow.Name, &unitRow.Version, &unitRow.SubscriptionType, &unitRow.SystemID, &unitRow.Created); err != nil {
+			logs.Logs.Println("[ERR][STORAGE][GET_UNITS] error in query row extraction" + err.Error())
+		}
+
+		// append results
+		results = append(results, unitRow)
+	}
+
+	unitMap := make(map[string]models.Unit)
+	for _, unitRow := range results {
+		unitMap[unitRow.ID] = unitRow
+	}
+
+	// return results
+	return unitMap, err
+}

--- a/api/storage/storage.go
+++ b/api/storage/storage.go
@@ -248,3 +248,47 @@ func UpdatePassword(accountUsername string, newPassword string) error {
 
 	return err
 }
+
+func AddUnit(unitID string, unitName string, version string, subscriptionType string, systemID string) error {
+	// get db
+	db := Instance()
+
+	// define query
+	_, err := db.Exec(
+		"INSERT INTO units (id, name, version, subscription_type, system_id) VALUES (?, ?, ?, ?, ?)",
+		unitID,
+		unitName,
+		version,
+		subscriptionType,
+		systemID,
+	)
+
+	// check error
+	if err != nil {
+		logs.Logs.Println("[ERR][STORAGE][ADD_UNIT] error in insert units query: " + err.Error())
+	}
+
+	return err
+}
+
+func UpdateUnit(unitID string, unitName string, version string, subscriptionType string, systemID string) error {
+	// get db
+	db := Instance()
+
+	// define query
+	_, err := db.Exec(
+		"UPDATE units set name = ?, version = ?, subscription_type = ?, system_id = ? WHERE id = ?",
+		unitName,
+		version,
+		subscriptionType,
+		systemID,
+		unitID,
+	)
+
+	// check error
+	if err != nil {
+		logs.Logs.Println("[ERR][STORAGE][UPDATE_UNIT] error in update units query: " + err.Error())
+	}
+
+	return err
+}


### PR DESCRIPTION
Changes:
- accept extra data during registration, data are stored in a new `units` table inside the sqlite database
- received data are exposed inside the `/units` APIs

See also: https://github.com/NethServer/nethsecurity/pull/371
Card: https://trello.com/c/k5iMcqLJ/367-controller-unit-label

