### PR TITLE
storage. add admin as normal user

### DIFF
--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -70,11 +70,6 @@ func InitJWT() *jwt.GinJWTMiddleware {
 			// read user password hash
 			passwordHash := storage.GetPassword(username)
 
-			// check login for admin
-			if username == configuration.Config.AdminUsername {
-				passwordHash = configuration.Config.AdminPassword
-			}
-
 			// check password
 			valid := utils.CheckPasswordHash(password, passwordHash)
 

--- a/api/storage/storage.go
+++ b/api/storage/storage.go
@@ -92,19 +92,11 @@ func AddAccount(account models.Account) error {
 	// get db
 	db := Instance()
 
-	// get account password
-	password := account.Password
-
-	// admin password is already hashed, for normal user hash it
-	if account.ID != 1 {
-		password = utils.HashPassword(account.Password)
-	}
-
 	// define query
 	_, err := db.Exec(
 		"INSERT INTO accounts (id, username, password, display_name, created) VALUES (null, ?, ?, ?, ?)",
 		account.Username,
-		password,
+		utils.HashPassword(account.Password),
 		account.DisplayName,
 		account.Created.Format(time.RFC3339),
 	)

--- a/api/storage/storage.go
+++ b/api/storage/storage.go
@@ -77,7 +77,7 @@ func Init() *sql.DB {
 			ID:          1,
 			Username:    configuration.Config.AdminUsername,
 			Password:    configuration.Config.AdminPassword,
-			DisplayName: "Super Admin user",
+			DisplayName: "Administrator",
 			Created:     time.Now(),
 		}
 
@@ -92,12 +92,12 @@ func AddAccount(account models.Account) error {
 	// get db
 	db := Instance()
 
-	// hash account password
-	password := utils.HashPassword(account.Password)
+	// get account password
+	password := account.Password
 
-	// admin password is already hashed
-	if account.ID == 1 {
-		password = account.Password
+	// admin password is already hashed, for normal user hash it
+	if account.ID != 1 {
+		password = utils.HashPassword(account.Password)
 	}
 
 	// define query


### PR DESCRIPTION
Add Admin user as normal user:
- When the API server starts, it checks for the administrator user and, if it does not exist, adds it to the `accounts` table.
- On the middleware, the exception for the administrator user has been removed, authentication is now standard for all accounts