### PR TITLE
api: add subscription limits

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -567,7 +567,8 @@ CGO_ENABLED=0 go build
             "fqdn": "controller.ns8.local",
             "grafana_path": "/grafana",
             "prometheus_path": "/prometheus",
-            "webssh_path": "/webssh"
+            "webssh_path": "/webssh",
+            "valid_subscription": false
         },
         "message": "success"
      }

--- a/api/configuration/configuration.go
+++ b/api/configuration/configuration.go
@@ -56,6 +56,8 @@ type Configuration struct {
 	FQDN string `json:"fqdn"`
 
 	CacheTTL string `json:"cache_ttl"`
+
+	ValidSubscription bool `json:"valid_subscription"`
 }
 
 var Config = Configuration{}
@@ -227,5 +229,11 @@ func Init() {
 		Config.CacheTTL = os.Getenv("CACHE_TTL")
 	} else {
 		Config.CacheTTL = "7200"
+	}
+
+	if os.Getenv("VALID_SUBSCRIPTION") != "" {
+		Config.ValidSubscription = os.Getenv("VALID_SUBSCRIPTION") == "true"
+	} else {
+		Config.ValidSubscription = false
 	}
 }

--- a/api/methods/defaults.go
+++ b/api/methods/defaults.go
@@ -24,10 +24,11 @@ func GetDefaults(c *gin.Context) {
 		Code:    200,
 		Message: "success",
 		Data: gin.H{
-			"fqdn":            configuration.Config.FQDN,
-			"prometheus_path": configuration.Config.PrometheusPath,
-			"webssh_path":     configuration.Config.WebSSHPath,
-			"grafana_path":    configuration.Config.GrafanaPath,
+			"fqdn":               configuration.Config.FQDN,
+			"prometheus_path":    configuration.Config.PrometheusPath,
+			"webssh_path":        configuration.Config.WebSSHPath,
+			"grafana_path":       configuration.Config.GrafanaPath,
+			"valid_subscription": configuration.Config.ValidSubscription,
 		},
 	}))
 }

--- a/api/methods/unit.go
+++ b/api/methods/unit.go
@@ -400,6 +400,16 @@ func RegisterUnit(c *gin.Context) {
 		return
 	}
 
+	// if the controller does not have a subscription, the unit must NOT have a valid subscription too
+	if !configuration.Config.ValidSubscription && jsonRequest.SubscriptionType != "" {
+		c.JSON(http.StatusForbidden, structs.Map(response.StatusBadRequest{
+			Code:    403,
+			Message: "subscription is not allowed",
+			Data:    "",
+		}))
+		return
+	}
+
 	// check openvpn conf exists
 	if _, err := os.Stat(configuration.Config.OpenVPNPKIDir + "/issued/" + jsonRequest.UnitId + ".crt"); err == nil {
 		// read ca


### PR DESCRIPTION
Changes:
- added a new `VALID_SUBSCRIPTION` env variable, it can be `true` or `false` (boolean)
- get-defaults API now returns a new `valid_subscription` field
- register API does not accept units without subscription if the controller has a valid subscription
- add API allows maximum 3 units if the controller does not have a valid subscription
- register API does not accept units with a subscription if the controller does not have a valid subscription

See https://github.com/NethServer/nethsecurity/issues/416