### PR TITLE
vpn: do not remove .info file on disconnect

### DIFF
--- a/vpn/handle-disconnection
+++ b/vpn/handle-disconnection
@@ -3,4 +3,3 @@
 # Remove openvpn instance
 username=$common_name
 rm -f /etc/openvpn/status/$username.vpn
-rm -f /etc/openvpn/status/$username.info


### PR DESCRIPTION
The info file contains the name of the unit along with the installed version.
Such information are useful also when the unit has been temporary disconnected from the controller.

If the file is not present, the user can't see the name of the disconnected user but just the uuid which can be hardly linked to the unit name.

Before:
![image](https://github.com/user-attachments/assets/d266187f-bedb-4366-a727-ae7179e6d27d)


After:
![image](https://github.com/user-attachments/assets/f3a4864f-bd85-4b3e-8360-3417cf697d4c)
