### PR TITLE
fix(vpn): generate CRL fro 3650 days

### DIFF
--- a/api/methods/unit.go
+++ b/api/methods/unit.go
@@ -500,6 +500,7 @@ func DeleteUnit(c *gin.Context) {
 	cmdGen.Env = append(os.Environ(),
 		"EASYRSA_BATCH=1",
 		"EASYRSA_PKI="+configuration.Config.OpenVPNPKIDir,
+		"EASYRSA_CRL_DAYS=3650",
 	)
 	if err := cmdGen.Run(); err != nil {
 		c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{

--- a/vpn/entrypoint.sh
+++ b/vpn/entrypoint.sh
@@ -14,7 +14,7 @@ if [ ! -f /etc/openvpn/pki/ca.crt ]; then
     EASYRSA_BATCH=1 EASYRSA_REQ_CN=$cn /usr/share/easy-rsa/easyrsa build-ca nopass
     openssl dhparam -dsaparam -out pki/dh.pem 2048
     EASYRSA_BATCH=1 EASYRSA_REQ_CN=$cn /usr/share/easy-rsa/easyrsa build-server-full server nopass
-    EASYRSA_BATCH=1 EASYRSA_REQ_CN=$cn /usr/share/easy-rsa/easyrsa gen-crl
+    EASYRSA_BATCH=1 EASYRSA_CRL_DAYS=3560 EASYRSA_REQ_CN=$cn /usr/share/easy-rsa/easyrsa gen-crl
     cd -
 fi
 


### PR DESCRIPTION
If removal of unit doesn't happen in 6 months CRL doesn't get generated again and any VPN connection fails.
Extending the initial duration of the CRL to 10 years, and every recurrent generation by the same amount.

Ref:
- https://github.com/NethServer/nethsecurity/issues/1143
