### PR TITLE
feat(api): add prometheus targets endpoint

### DIFF
--- a/api/configuration/configuration.go
+++ b/api/configuration/configuration.go
@@ -75,6 +75,10 @@ type Configuration struct {
 	EncryptionKey string `json:"encryption_key"`
 
 	PlatformInfo models.PlatformInfo `json:"platform_info"`
+
+	// Prometheus basi authenticatin to access target list
+	PrometheusAuthUsername string `json:"prometheus_auth_username"`
+	PrometheusAuthPassword string `json:"prometheus_auth_password"`
 }
 
 var Config = Configuration{}
@@ -316,5 +320,17 @@ func Init() {
 		Config.PlatformInfo = platformInfo
 	} else {
 		Config.PlatformInfo = models.PlatformInfo{}
+	}
+
+	if os.Getenv("PROMETHEUS_AUTH_USERNAME") != "" {
+		Config.PrometheusAuthUsername = os.Getenv("PROMETHEUS_AUTH_USERNAME")
+	} else {
+		Config.PrometheusAuthUsername = "prometheus"
+	}
+
+	if os.Getenv("PROMETHEUS_AUTH_PASSWORD") != "" {
+		Config.PrometheusAuthPassword = os.Getenv("PROMETHEUS_AUTH_PASSWORD")
+	} else {
+		Config.PrometheusAuthPassword = "prometheus"
 	}
 }

--- a/api/main.go
+++ b/api/main.go
@@ -177,6 +177,12 @@ func setup() *gin.Engine {
 		c.Status(http.StatusOK)
 	})
 
+	// Prometheus metrics endpoint
+	prometheus := router.Group("/prometheus", gin.BasicAuth(gin.Accounts{
+		configuration.Config.PrometheusAuthUsername: configuration.Config.PrometheusAuthPassword,
+	}))
+	prometheus.GET("/targets", methods.GetPrometheusTargets)
+
 	// handle missing endpoint
 	router.NoRoute(func(c *gin.Context) {
 		c.JSON(http.StatusNotFound, structs.Map(response.StatusNotFound{

--- a/api/methods/unit.go
+++ b/api/methods/unit.go
@@ -966,7 +966,7 @@ func GetPrometheusTargets(c *gin.Context) {
 
 		if ok1 && ok2 {
 			target := gin.H{
-				"targets": []string{unitIp},
+				"targets": []string{unitIp + ":19999"},
 				"labels": gin.H{
 					"node":                  unitIp,
 					"unit":                  unitId,

--- a/api/methods/unit.go
+++ b/api/methods/unit.go
@@ -971,7 +971,6 @@ func GetPrometheusTargets(c *gin.Context) {
 					"node":             unitIp,
 					"unit":             unitId,
 					"__metrics_path__": "/api/v1/allmetrics?format=prometheus&help=no"},
-				"__scrape_timeout__": "30s", // VPN can be slow, so we set a longer scrape timeout
 			}
 			targets = append(targets, target)
 		}

--- a/api/methods/unit.go
+++ b/api/methods/unit.go
@@ -968,11 +968,10 @@ func GetPrometheusTargets(c *gin.Context) {
 			target := gin.H{
 				"targets": []string{unitIp + ":19999"},
 				"labels": gin.H{
-					"node":                  unitIp,
-					"unit":                  unitId,
-					"__meta_metrics_path__": "/api/v1/allmetrics?format=prometheus&help=no",
-					"__meta_prometheus_job": "node",
-				},
+					"node":             unitIp,
+					"unit":             unitId,
+					"__metrics_path__": "/api/v1/allmetrics?format=prometheus&help=no"},
+				"__scrape_timeout__": "30s", // VPN can be slow, so we set a longer scrape timeout
 			}
 			targets = append(targets, target)
 		}


### PR DESCRIPTION
Expose the list of configured units for Prometheus scrape. The request is authenticated using PROMETHEUS_AUTH_USERNAME and PROMETHEUS_AUTH_PASSWORD.

Previously, a script on NS8 was scraping the clients dir to find new targets. But, due to a bug, obsolete targets where not removed.