### PR TITLE
fix(api): refactor migration process

### DIFF
--- a/api/storage/report_schema.sql.tmpl
+++ b/api/storage/report_schema.sql.tmpl
@@ -66,7 +66,8 @@ CREATE TABLE IF NOT EXISTS openvpn_config (
     name TEXT,
     device TEXT NOT NULL,
     type TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_unit FOREIGN KEY(uuid) REFERENCES units(uuid) ON DELETE CASCADE
 );
 
 -- This table contains the list of WAN interfaces configured inside the units
@@ -75,7 +76,8 @@ CREATE TABLE IF NOT EXISTS wan_config (
     interface TEXT NOT NULL,
     device TEXT,
     status TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_unit FOREIGN KEY(uuid) REFERENCES units(uuid) ON DELETE CASCADE
 );
 
 -- General retention policies

--- a/api/storage/storage.go
+++ b/api/storage/storage.go
@@ -54,14 +54,23 @@ func Init() *pgxpool.Pool {
 	// Initialize PostgreSQL connection and schema
 	dbpool, dbctx = InitReportDb()
 
-	// Migrate unit info from file to Postgres if needed
-	migratedUnits := MigrateUnitInfoFromFileToPostgres()
+	toBeMigratedUnits := listCCDFiles()
 
-	// Migrate users from SQLite to Postgres if needed
-	MigrateUsersFromSqliteToPostgres(migratedUnits)
+	if len(toBeMigratedUnits) > 0 {
+		// Migrate unit info from file to Postgres if needed
+		migrateUnitInfoFromFileToPostgres(toBeMigratedUnits)
 
-	// Migrate unit credentials from file to Postgres
-	MigrateUnitCredentialsFromFileToPostgres()
+		// Migrate users from SQLite to Postgres if needed
+		migrateUsersFromSqliteToPostgres(toBeMigratedUnits)
+
+		// Migrate unit credentials from file to Postgres
+		migrateUnitCredentialsFromFileToPostgres()
+
+		// Remove all units that are not inside the migrated units
+		cleanupUnusedUnits(toBeMigratedUnits)
+	} else {
+		logs.Logs.Println("[INFO][MIGRATION] skipping migration: no units found in CCD directory")
+	}
 
 	ReloadACLs()
 
@@ -100,8 +109,64 @@ func Init() *pgxpool.Pool {
 	return dbpool
 }
 
-// MigrateUsersFromSqliteToPostgres migrates users from SQLite to PostgreSQL if needed
-func MigrateUsersFromSqliteToPostgres(units []string) {
+func listCCDFiles() []string {
+	ret := make([]string, 0)
+	// If the dir does not exists, just return
+	if _, err := os.Stat(configuration.Config.OpenVPNCCDDir); os.IsNotExist(err) {
+		fmt.Println("[INFO][MIGRATION] OpenVPN CCD directory does not exist")
+		return ret
+	}
+	files, err := os.ReadDir(configuration.Config.OpenVPNCCDDir)
+	if err != nil {
+		logs.Logs.Println("[WARNING][MIGRATION] error reading OpenVPN CCD directory: " + err.Error())
+		return ret
+	}
+	for _, file := range files {
+		if !file.IsDir() {
+			ret = append(ret, file.Name())
+		}
+	}
+	return ret
+}
+
+func cleanupUnusedUnits(units []string) {
+	pgpool, pgctx := ReportInstance()
+	if len(units) == 0 {
+		return
+	}
+
+	// Remove all units and credentials that are not in the provided list
+	if len(units) == 0 {
+		return
+	}
+	// Build the list of UUIDs as a comma-separated string for the SQL IN clause
+	quoted := make([]string, len(units))
+	for i, v := range units {
+		quoted[i] = fmt.Sprintf("'%s'", v)
+	}
+	inClause := strings.Join(quoted, ",")
+
+	// Delete from unit_credentials table for units not in the list
+	queryCreds := fmt.Sprintf("DELETE FROM unit_credentials WHERE uuid NOT IN (%s)", inClause)
+	res, err := pgpool.Exec(pgctx, queryCreds)
+	if err != nil {
+		logs.Logs.Println("[ERR][MIGRATION] error deleting unused unit credentials: " + err.Error())
+	} else {
+		logs.Logs.Printf("[INFO][MIGRATION] cleaned up %d unused unit credentials not in the list of migrated units\n", res.RowsAffected())
+	}
+
+	// Delete from units table for units not in the list
+	query := fmt.Sprintf("DELETE FROM units WHERE uuid NOT IN (%s)", inClause)
+	res, err = pgpool.Exec(pgctx, query)
+	if err != nil {
+		logs.Logs.Println("[ERR][MIGRATION] error deleting unused units: " + err.Error())
+	} else {
+		logs.Logs.Printf("[INFO][MIGRATION] cleaned up %d unused units not in the list of migrated units\n", res.RowsAffected())
+	}
+}
+
+// migrateUsersFromSqliteToPostgres migrates users from SQLite to PostgreSQL if needed
+func migrateUsersFromSqliteToPostgres(units []string) {
 	// 1. Check if SQLite DB exists
 	sqlitePath := configuration.Config.DataDir + "/db.sqlite"
 	if _, err := os.Stat(sqlitePath); os.IsNotExist(err) {
@@ -573,89 +638,72 @@ func loadUnitIP(unitId string) string {
 	return parts[1]
 }
 
-func MigrateUnitInfoFromFileToPostgres() []string {
-	ret := make([]string, 0)
-	// Search for all *.info file inside Config.OpenVPNStatusDir
-	// If the dir does not exists, just return
-	if _, err := os.Stat(configuration.Config.OpenVPNStatusDir); os.IsNotExist(err) {
-		return ret
-	}
-	files, err := os.ReadDir(configuration.Config.OpenVPNCCDDir)
-	if err != nil {
-		logs.Logs.Println("[WARNING][MIGRATION] error reading OpenVPN status directory: " + err.Error())
-		return ret
-	}
-	for _, file := range files {
-		if !file.IsDir() {
-			uuid := file.Name()
-			softErrors := 0
-			infoFile := configuration.Config.OpenVPNStatusDir + "/" + uuid + ".info"
-			ccdFile := configuration.Config.OpenVPNCCDDir + "/" + uuid
-			proxyFile := configuration.Config.OpenVPNProxyDir + "/" + uuid + ".yaml"
-			// If the proxy file does not exist, skip migration for this unit: this means that the unit is in a dirty state
-			if _, err := os.Stat(proxyFile); os.IsNotExist(err) {
-				logs.Logs.Println("[INFO][MIGRATION] proxy file missing for unit", uuid, "- skipping migration (dirty state)")
-				continue
-			}
+func migrateUnitInfoFromFileToPostgres(toBeMigratedUnits []string) {
+	migrated := 0
+	for _, uuid := range toBeMigratedUnits {
+		softErrors := 0
+		infoFile := configuration.Config.OpenVPNStatusDir + "/" + uuid + ".info"
+		ccdFile := configuration.Config.OpenVPNCCDDir + "/" + uuid
+		proxyFile := configuration.Config.OpenVPNProxyDir + "/" + uuid + ".yaml"
+		// If the proxy file does not exist, skip migration for this unit: this means that the unit is in a dirty state
+		if _, err := os.Stat(proxyFile); os.IsNotExist(err) {
+			logs.Logs.Println("[INFO][MIGRATION] proxy file missing for unit", uuid, "- skipping migration (dirty state)")
+			continue
+		}
 
-			// uuid.vpn file is not migrated because it does not persist: vpn status is restored as soon as the client re-connects
-			ipaddr := loadUnitIP(uuid)
+		// uuid.vpn file is not migrated because it does not persist: vpn status is restored as soon as the client re-connects
+		ipaddr := loadUnitIP(uuid)
 
-			// Check if the unit already exists in Postgres
-			exists, err := UnitExists(uuid)
-			if err != nil {
-				logs.Logs.Println("[WARNING][MIGRATION] error checking if unit exists in Postgres:", err.Error())
-				continue
-			}
-			if exists {
-				logs.Logs.Println("[INFO][MIGRATION] unit", uuid, "already exists in Postgres, skipping migration")
-				continue
-			}
-			// ignore the error
+		// Check if the unit already exists in Postgres
+		exists, err := UnitExists(uuid)
+		if err != nil {
+			logs.Logs.Println("[WARNING][MIGRATION] error checking if unit exists in Postgres:", err.Error())
+			continue
+		}
+		if !exists {
 			addUnitErr := AddUnit(uuid, ipaddr)
 			if addUnitErr != nil {
 				logs.Logs.Println("[WARNING][MIGRATION] error adding unit to Postgres:", uuid, addUnitErr.Error())
 				continue
 			}
-			if _, err := os.Stat(infoFile); err == nil {
-				// read file, parse as JSON and then call AddUnit
-				data, err := os.ReadFile(infoFile)
-				if err != nil {
-					logs.Logs.Println("[WARNING][MIGRATION] error reading file:", infoFile, err.Error())
-					softErrors++
-					continue
-				}
-				var info models.UnitInfo
-				if err := json.Unmarshal(data, &info); err != nil {
-					logs.Logs.Println("[WARNING][MIGRATION] error parsing JSON in file:", infoFile, err.Error())
-					softErrors++
-					continue
-				}
-				if err := SetUnitInfo(uuid, info); err != nil {
-					logs.Logs.Println("[WARNING][MIGRATION] error setting unit info for", uuid, ":", err.Error())
-					softErrors++
-				}
-				// remove the info file
-				if err := os.Remove(infoFile); err != nil {
-					logs.Logs.Println("[WARNING][MIGRATION] error removing file:", infoFile, err.Error())
-					softErrors++
-				} else {
-					logs.Logs.Println("[INFO][MIGRATION] removed file:", infoFile)
-				}
-			}
-			// remove ccd file
-			if err := os.Remove(ccdFile); err != nil {
-				logs.Logs.Println("[WARNING][MIGRATION] error removing file:", ccdFile, err.Error())
-			} else {
-				logs.Logs.Println("[INFO][MIGRATION] removed file:", ccdFile)
-			}
-			ret = append(ret, uuid)
-			softErrors = 0
-			logs.Logs.Println("[INFO][MIGRATION] migrated unit", uuid, "with IP address", ipaddr, "Error count:", softErrors)
 		}
+		if _, err := os.Stat(infoFile); err == nil {
+			// read file, parse as JSON and then set unit info
+			data, err := os.ReadFile(infoFile)
+			if err != nil {
+				logs.Logs.Println("[WARNING][MIGRATION] error reading file:", infoFile, err.Error())
+				softErrors++
+				continue
+			}
+			var info models.UnitInfo
+			if err := json.Unmarshal(data, &info); err != nil {
+				logs.Logs.Println("[WARNING][MIGRATION] error parsing JSON in file:", infoFile, err.Error())
+				softErrors++
+				continue
+			}
+			if err := SetUnitInfo(uuid, info); err != nil {
+				logs.Logs.Println("[WARNING][MIGRATION] error setting unit info for", uuid, ":", err.Error())
+				softErrors++
+			}
+			// remove the info file
+			if err := os.Remove(infoFile); err != nil {
+				logs.Logs.Println("[WARNING][MIGRATION] error removing file:", infoFile, err.Error())
+				softErrors++
+			} else {
+				logs.Logs.Println("[INFO][MIGRATION] removed file:", infoFile)
+			}
+		}
+		// remove ccd file
+		if err := os.Remove(ccdFile); err != nil {
+			logs.Logs.Println("[WARNING][MIGRATION] error removing file:", ccdFile, err.Error())
+		} else {
+			logs.Logs.Println("[INFO][MIGRATION] removed file:", ccdFile)
+		}
+		softErrors = 0
+		migrated++
+		logs.Logs.Println("[INFO][MIGRATION] migrated unit", uuid, "with IP address", ipaddr, "Error count:", softErrors)
 	}
-	logs.Logs.Println("[INFO][MIGRATION] migrated", len(ret), "units from file to Postgres")
-	return ret
+	logs.Logs.Println("[INFO][MIGRATION] migrated", migrated, "units from file to Postgres")
 }
 
 func UnitExists(uuid string) (bool, error) {
@@ -1146,7 +1194,7 @@ func SetUnitCredentials(uuid string, username string, password string) error {
 	return nil
 }
 
-func MigrateUnitCredentialsFromFileToPostgres() {
+func migrateUnitCredentialsFromFileToPostgres() {
 	migrated := 0
 	files, err := os.ReadDir(configuration.Config.CredentialsDir)
 	if err != nil {

--- a/api/storage/upgrade_schema.sql
+++ b/api/storage/upgrade_schema.sql
@@ -12,3 +12,26 @@ ALTER TABLE units ADD COLUMN IF NOT EXISTS info JSONB;
 ALTER TABLE units ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
 ALTER TABLE units ADD COLUMN IF NOT EXISTS vpn_address TEXT;
 ALTER TABLE units ADD COLUMN IF NOT EXISTS vpn_connected_since TIMESTAMP NULL;
+/* Add missing constraints to existing tables */
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE constraint_name = 'fk_unit'
+          AND table_name = 'openvpn_config'
+    ) THEN
+        ALTER TABLE openvpn_config
+            ADD CONSTRAINT fk_unit FOREIGN KEY(uuid) REFERENCES units(uuid) ON DELETE CASCADE;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE constraint_name = 'fk_unit'
+          AND table_name = 'wan_config'
+    ) THEN
+        ALTER TABLE wan_config
+            ADD CONSTRAINT fk_unit FOREIGN KEY(uuid) REFERENCES units(uuid) ON DELETE CASCADE;
+    END IF;
+END$$;


### PR DESCRIPTION
Changes:
- execute the migration only if there are CCD files
- add delete constraints to openvpn_config and wan_config tables
- remove from database all units that do not have a CCD file: avoid showing ghost units after migration
- chore: migration functions are now private

NethServer/nethsecurity#1300